### PR TITLE
Upgrade python version to 3.9

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,7 +20,7 @@ jobs:
     # The type of runner that the job will run on
     strategy:
       matrix:
-        python-versions: [3.8]
+        python-versions: [3.9]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        python-versions: [ 3.8 ]
+        python-versions: [ 3.9 ]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        python-versions: [3.8]
+        python-versions: [3.9]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: 24.4.2
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.9
   - repo: https://github.com/pycqa/flake8
     rev: 5.0.4
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers=[
     'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
 ]
 packages = [
     { include = "lifedb" },
@@ -21,7 +21,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.8,<4.0"
+python = ">=3.9,<4.0"
 
 black  = { version = "^24.4.2", optional = true}
 bump2version = {version = "^1.0.1", optional = true}
@@ -39,6 +39,10 @@ mkdocs-include-markdown-plugin  = { version = "^1.0.0", optional = true}
 mkdocs-material  = { version = "^8.2.15", optional = true}
 mkdocs-material-extensions  = { version = "^1.0.1", optional = true}
 mypy = {version = "^1.13.0", optional = true}
+# numpy 2.0 is not compatible with pandas 1.5, need to pin because
+# pandas does not properly specify numpy dependency
+# https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from
+numpy = { version = "^1.26.0" }
 pandas = { version = "^1.5.3" }
 pip  = { version = "^24.0.0", optional = true}
 pre-commit = {version = "^2.12.0", optional = true}
@@ -77,7 +81,7 @@ doc = [
     ]
 
 [tool.black]
-target-version = ['py36', 'py37', 'py38']
+target-version = ['py39']
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,11 +40,11 @@ exclude_lines =
 
 [tox:tox]
 isolated_build = true
-envlist = py38, format, lint, build
+envlist = py39, format, lint, build
 
 [gh-actions]
 python =
-    3.8: py38, format, lint, build
+    3.9: py39, format, lint, build
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
Python 3.9 is required for Dagster.